### PR TITLE
Redirect gallery

### DIFF
--- a/gmtcn.sh
+++ b/gmtcn.sh
@@ -85,7 +85,7 @@ in
         exit
         ;;
     gallery)
-        ${open} "${baseurl}/examples"
+        ${open} "${baseurl}/gallery"
         exit
         ;;
     started|advanced)


### PR DESCRIPTION
之前是定向到 https://docs.gmt-china.org/latest/examples/

现在改为 https://docs.gmt-china.org/latest/gallery/